### PR TITLE
Add skylight to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'uglifier'
 gem 'fabrication'
 gem 'faker'
 gem 'rails_12factor', group: :production
+gem 'skylight'
 
 group :development, :test do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,8 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (~> 1.1)
     shellany (0.0.1)
+    skylight (0.6.0)
+      activesupport (>= 3.0.0)
     slop (3.6.0)
     spring (1.3.3)
     sprockets (2.12.3)
@@ -199,5 +201,6 @@ DEPENDENCIES
   rails_12factor
   rspec-rails
   sass-rails
+  skylight
   spring
   uglifier


### PR DESCRIPTION
Skylight is needed in Gemfile to follow [this tutorial](https://github.com/turingschool/lesson_plans/blob/master/ruby_04-apis_and_scalability/load_testing_and_production_performance_monitoring.markdown).